### PR TITLE
Bug réglé pour la naviguation à la pageCommandes.

### DIFF
--- a/TP214E/Pages/PageAccueil.xaml.cs
+++ b/TP214E/Pages/PageAccueil.xaml.cs
@@ -35,6 +35,8 @@ namespace TP214E
 
         private void BoutonCommandes_Click(object sender, RoutedEventArgs e)
         {
+            PageCommandes frmCommandes = new PageCommandes();
+
             this.NavigationService.Navigate(new Uri("Pages/PageCommandes.xaml", UriKind.Relative));
         }
     }

--- a/TP214E/Pages/PageCommandes.xaml
+++ b/TP214E/Pages/PageCommandes.xaml
@@ -1,12 +1,12 @@
-﻿<Window x:Class="TP214E.Pages.PageCommandes"
+﻿<Page x:Class="TP214E.PageCommandes"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:TP214E.Pages"
+        xmlns:local="clr-namespace:TP214E"
         mc:Ignorable="d"
-        Title="PageCommandes" Height="450" Width="800">
+        Title="Commandes" Height="450" Width="800">
     <Grid>
         
     </Grid>
-</Window>
+</Page>

--- a/TP214E/Pages/PageCommandes.xaml.cs
+++ b/TP214E/Pages/PageCommandes.xaml.cs
@@ -10,12 +10,12 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 
-namespace TP214E.Pages
+namespace TP214E
 {
     /// <summary>
     /// Logique d'interaction pour PageCommandes.xaml
     /// </summary>
-    public partial class PageCommandes : Window
+    public partial class PageCommandes : Page
     {
         public PageCommandes()
         {


### PR DESCRIPTION
L'erreur était que la PageCommande avait été créée comme une Window au lieu d'une Page, dans PageCommandes.xaml.cs la classe héritait de Window au lieu de Page, et dans PageCommandes.xaml la première balise était une balise Window au lieu de Page.